### PR TITLE
chore: add 1inch swap params log

### DIFF
--- a/internal/jobs/flashbuy_v2.go
+++ b/internal/jobs/flashbuy_v2.go
@@ -322,6 +322,14 @@ func (j *buyFlashAuctionV2Job) flashLiquidate(log *logrus.Entry, auctionID *big.
 	}
 	ctx := context.Background()
 
+	log.WithFields(logrus.Fields{
+		"swap.src":      collateralReal.Hex(),
+		"swap.dst":      j.hayAddr.Hex(),
+		"swap.amount":   scaledInchAmt.String(),
+		"swap.from":     j.cfg.Contract.Liquidator,
+		"swap.slippage": j.cfg.FlushBuy.OneInchSlip,
+	}).Info("Prepared 1inch swap params")
+
 	swapData, err := client.GetSwap(ctx, aggregation.GetSwapParams{
 		Src:              collateralReal.Hex(),
 		Dst:              j.hayAddr.Hex(),


### PR DESCRIPTION
Background:
Need swap params log to trace back root causes
Solution:
Added detailed logging of all 1inch swap request parameters (`src`, `dst`, `amount`, `from`, `slippage`, etc.) alongside existing auction-related fields. This makes it easier to debug failed swaps and trace back root causes 